### PR TITLE
Add max_conn configuration.

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -52,10 +52,11 @@ The lock listed first has higher order than locks listed under it.
 
     This lock is to protect file information cached in Cacher.
 
-2. `Cacher.dlLock`
+2. `Cacher.dlLock` and `Cacher.hostLock`
 
-    This lock is to protect download channels and cached response statuses.
-    Strictly, this lock is used independently from other locks.
+    These locks are to protect download channels, cached response statuses,
+    and semaphores for each upstream host.
+    Strictly, these are used independently from other locks.
 
 3. `Storage.mu`
 

--- a/cacher_config.go
+++ b/cacher_config.go
@@ -4,6 +4,7 @@ const (
 	defaultCheckInterval = 15
 	defaultCachePeriod   = 3
 	defaultCacheCapacity = 1
+	defaultMaxConns      = 10
 )
 
 // CacherConfig is a struct to read TOML configurations.
@@ -41,6 +42,12 @@ type CacherConfig struct {
 	//
 	// Unit is GiB.  Default is 1 GiB.
 	CacheCapacity int `toml:"cache_capacity"`
+
+	// MaxConns specifies the maximum concurrent connections to an
+	// upstream host.
+	//
+	// Zero disables limit on the number of connections.
+	MaxConns int `toml:"max_conns"`
 
 	// Mapping specifies mapping between prefixes and APT URLs.
 	Mapping map[string]string `toml:"mapping"`

--- a/cacher_config_test.go
+++ b/cacher_config_test.go
@@ -35,6 +35,9 @@ func TestCacherConfig(t *testing.T) {
 	if config.CacheCapacity != 21 {
 		t.Error(`config.CacheCapacity != 21`)
 	}
+	if config.MaxConns != 3 {
+		t.Error(`config.MaxConns != 3`)
+	}
 
 	if config.Mapping["ubuntu"] != "http://archive.ubuntu.com/ubuntu" {
 		t.Error(`config.Mapping["ubuntu"]`)

--- a/cmd/go-apt-cacher/go-apt-cacher.toml
+++ b/cmd/go-apt-cacher/go-apt-cacher.toml
@@ -19,6 +19,11 @@ cache_dir = "/var/spool/go-apt-cacher/cache"
 # Default: 1 GiB
 cache_capacity = 1
 
+# Maximum concurrent connections for an upstream server.
+# Setting this 0 disables limit on the number of connections.
+# Default: 10
+max_conns = 10
+
 # mapping declares which prefix maps to a Debian repository URL.
 # prefix must match this regexp: ^[a-z0-9._-]+$
 [mapping]

--- a/cmd/go-apt-cacher/main.go
+++ b/cmd/go-apt-cacher/main.go
@@ -18,6 +18,7 @@ import (
 const (
 	defaultConfigPath = "/etc/go-apt-cacher.toml"
 	defaultAddress    = ":3142"
+	defaultMaxConns   = 10
 )
 
 var (
@@ -44,6 +45,9 @@ func main() {
 			"_keys": fmt.Sprintf("%#v", md.Undecoded()),
 		})
 		os.Exit(1)
+	}
+	if !md.IsDefined("max_conns") {
+		config.MaxConns = defaultMaxConns
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())

--- a/t/cacher.toml
+++ b/t/cacher.toml
@@ -3,6 +3,7 @@ cache_period = 5
 meta_dir = "/tmp/meta"
 cache_dir = "/tmp/cache"
 cache_capacity = 21
+max_conns = 3
 
 [mapping]
 ubuntu = "http://archive.ubuntu.com/ubuntu"


### PR DESCRIPTION
This PR introduces a new configuration option "max_conn"
to limit the number of concurrent connections for an upstream server.

Motivations:

* To behave itself well for upstream servers.
* To avoid consuming too much memory when downloading tons of items.