### PR TITLE
Add a suffix to cache file names

### DIFF
--- a/storage_test.go
+++ b/storage_test.go
@@ -236,10 +236,16 @@ func TestStorageLoad(t *testing.T) {
 	defer os.RemoveAll(dir)
 
 	for k, v := range files {
-		err := ioutil.WriteFile(filepath.Join(dir, k), v, 0644)
+		err := ioutil.WriteFile(filepath.Join(dir, k+fileSuffix), v, 0644)
 		if err != nil {
 			t.Fatal(err)
 		}
+	}
+
+	// dummy should be ignored as it does not have a proper suffix.
+	err = ioutil.WriteFile(filepath.Join(dir, "dummy"), []byte{'d'}, 0644)
+	if err != nil {
+		t.Fatal(err)
 	}
 
 	cm := NewStorage(dir, 0)


### PR DESCRIPTION
Suppose a URL path "/foo/bar" is cached and stored as "foo/bar".
This prevents another URL path "/foo/bar/zot" being cached as
it needs to create "foo/bar" as a directory, but a regular file
has already been there.

To resolve this issue, Storage adds a consistent prefix (".cache")
to the cache file names.